### PR TITLE
Add LiveDNS nameservers data source

### DIFF
--- a/gandi/data_livedns_domain.go
+++ b/gandi/data_livedns_domain.go
@@ -2,7 +2,6 @@ package gandi
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -23,7 +22,6 @@ func dataSourceLiveDNSDomain() *schema.Resource {
 func dataSourceLiveDNSDomainRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients).LiveDNS
 	name := d.Get("name").(string)
-	log.Printf("[INFO] Reading Gandi zone '%s'", name)
 	found, err := client.GetDomain(name)
 	if err != nil {
 		return fmt.Errorf("Unknown domain '%s': %w", name, err)

--- a/gandi/data_livedns_domain_ns.go
+++ b/gandi/data_livedns_domain_ns.go
@@ -1,0 +1,37 @@
+package gandi
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceLiveDNSDomainNS() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceLiveDNSDomainNSRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The FQDN of the domain",
+			},
+			"nameservers": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: "A list of nameservers for the domain",
+			},
+		},
+	}
+}
+
+func dataSourceLiveDNSDomainNSRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients).LiveDNS
+	name := d.Get("name").(string)
+	ns, err := client.GetDomainNS(name)
+	if err != nil {
+		ns = []string{}
+	}
+
+	d.SetId(name)
+	d.Set("nameservers", ns)
+	return nil
+}

--- a/gandi/provider.go
+++ b/gandi/provider.go
@@ -12,27 +12,28 @@ import (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"key": &schema.Schema{
+			"key": {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("GANDI_KEY", nil),
 				Description: "A Gandi API key",
 			},
-			"sharing_id": &schema.Schema{
+			"sharing_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("GANDI_SHARING_ID", nil),
 				Description: "A Gandi Sharing ID",
 			},
-			"dry_run": &schema.Schema{
+			"dry_run": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Prevent the Domain provider from taking certain actions",
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"gandi_livedns_domain": dataSourceLiveDNSDomain(),
-			"gandi_domain":         dataSourceDomain(),
+			"gandi_livedns_domain":    dataSourceLiveDNSDomain(),
+			"gandi_livedns_domain_ns": dataSourceLiveDNSDomainNS(),
+			"gandi_domain":            dataSourceDomain(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"gandi_livedns_domain": resourceLiveDNSDomain(),


### PR DESCRIPTION
Use case for this, setting the domain nameservers to those from LiveDNS. On error it defaults to an empty array, so that it can be used when creating the domain - obviously there's no LiveDNS entry for a domain that does not yet exist.