### PR TITLE
Adjust to changes made in go-gandi/go-gandi#22

### DIFF
--- a/gandi/provider.go
+++ b/gandi/provider.go
@@ -45,8 +45,8 @@ func Provider() *schema.Provider {
 }
 
 type clients struct {
-	Domain  *domain.Domain
-	LiveDNS *livedns.LiveDNS
+	Domain  *domain.DomainAPI
+	LiveDNS *livedns.LiveDNSAPI
 }
 
 func getGandiClients(d *schema.ResourceData) (interface{}, error) {


### PR DESCRIPTION
domain.Domain -> domain.DomainAPI and livedns.LiveDNS to livedns.LiveDNSAPI

Hopefully this doesn't break things for other clients relyin on this library

Ensure that the release notes make note of the interface name changing.