### PR TITLE
Switch from golint in the gh action to golangci-lin# golint is no longer maintained. Switch to golangci-lint for linting

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,18 +30,17 @@ jobs:
     - name: Build
       run: |
         make cibuild
-  
+
     - name: Format
       uses: sjkaliski/go-github-actions/fmt@v1.0.0
       if: runner.os == 'Linux'
       env:
         GO_IGNORE_DIRS: "./vendor"
-    
+
     - name: Lint
-      uses: sjkaliski/go-github-actions/lint@v1.0.0
+      uses: golangci/golangci-lint-action@v2
       if: runner.os == 'Linux'
-      env:
-        GO_LINT_PATHS: "./gandi/..."
+      working-directory: "./gandi/..."
 
 # This still does something weird, comment out for now
 #    - name: TF Provider Lint


### PR DESCRIPTION
golint is no longer maintained. Switch to golangci-lint for linting in the workflow