### PR TITLE
Add simplehosting_instance resource

### DIFF
--- a/gandi/provider.go
+++ b/gandi/provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-gandi/go-gandi/domain"
 	"github.com/go-gandi/go-gandi/email"
 	"github.com/go-gandi/go-gandi/livedns"
+	"github.com/go-gandi/go-gandi/simplehosting"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -46,21 +47,23 @@ func Provider() *schema.Provider {
 			"gandi_mailbox":           dataSourceMailbox(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"gandi_livedns_domain":   resourceLiveDNSDomain(),
-			"gandi_livedns_record":   resourceLiveDNSRecord(),
-			"gandi_domain":           resourceDomain(),
-			"gandi_mailbox":          resourceMailbox(),
-			"gandi_email_forwarding": resourceEmailForwarding(),
-			"gandi_dnssec_key":       resourceDNSSECKey(),
+			"gandi_livedns_domain":         resourceLiveDNSDomain(),
+			"gandi_livedns_record":         resourceLiveDNSRecord(),
+			"gandi_domain":                 resourceDomain(),
+			"gandi_mailbox":                resourceMailbox(),
+			"gandi_email_forwarding":       resourceEmailForwarding(),
+			"gandi_dnssec_key":             resourceDNSSECKey(),
+			"gandi_simplehosting_instance": resourceSimpleHostingInstance(),
 		},
 		ConfigureFunc: getGandiClients,
 	}
 }
 
 type clients struct {
-	Domain  *domain.Domain
-	Email   *email.Email
-	LiveDNS *livedns.LiveDNS
+	Domain        *domain.Domain
+	Email         *email.Email
+	LiveDNS       *livedns.LiveDNS
+	SimpleHosting *simplehosting.SimpleHosting
 }
 
 func getGandiClients(d *schema.ResourceData) (interface{}, error) {
@@ -74,10 +77,12 @@ func getGandiClients(d *schema.ResourceData) (interface{}, error) {
 	liveDNS := gandi.NewLiveDNSClient(config)
 	email := gandi.NewEmailClient(config)
 	domainClient := gandi.NewDomainClient(config)
+	simpleHostingClient := gandi.NewSimpleHostingClient(config)
 
 	return &clients{
-		Domain:  domainClient,
-		Email:   email,
-		LiveDNS: liveDNS,
+		Domain:        domainClient,
+		Email:         email,
+		LiveDNS:       liveDNS,
+		SimpleHosting: simpleHostingClient,
 	}, nil
 }

--- a/gandi/provider_test.go
+++ b/gandi/provider_test.go
@@ -1,0 +1,28 @@
+package gandi
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider()
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"gandi": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}

--- a/gandi/resource_simplehosting_instance.go
+++ b/gandi/resource_simplehosting_instance.go
@@ -1,0 +1,137 @@
+package gandi
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-gandi/go-gandi/simplehosting"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceSimpleHostingInstance() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSimpleHostingInstanceCreate,
+		Read:   resourceSimpleHostingInstanceRead,
+		Delete: resourceSimpleHostingInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the SimpleHosting instance",
+			},
+			"size": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The size of the SimpleHosting instance ('s+', 'm', 'l' or 'xxl')",
+			},
+			"database_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the database type ('mysql' or 'pgsql')",
+			},
+			"language_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the language ('php', 'python', 'nodejs' or 'ruby')",
+			},
+			"location": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The datacenter location of the instance ('FR' or 'LU')",
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{Default: schema.DefaultTimeout(5 * time.Minute)},
+	}
+}
+
+func resourceSimpleHostingInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients).SimpleHosting
+	id := d.Id()
+	found, err := client.GetInstance(id)
+
+	if err != nil {
+		return fmt.Errorf("unknown simplehosting instance '%s': %w", id, err)
+	}
+	d.SetId(found.ID)
+	if err = d.Set("name", found.Name); err != nil {
+		return fmt.Errorf("failed to set name for %s: %w", d.Id(), err)
+	}
+	if err = d.Set("size", found.Size); err != nil {
+		return fmt.Errorf("failed to set size for %s: %w", d.Id(), err)
+	}
+	if err = d.Set("location", found.Datacenter.Region); err != nil {
+		return fmt.Errorf("failed to set location for %s: %w", d.Id(), err)
+	}
+	if err = d.Set("database_name", found.Database.Name); err != nil {
+		return fmt.Errorf("failed to set database_name for %s: %w", d.Id(), err)
+	}
+	if err = d.Set("language_name", found.Language.Name); err != nil {
+		return fmt.Errorf("failed to set language_name for %s: %w", d.Id(), err)
+	}
+	return nil
+}
+
+func resourceSimpleHostingInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients).SimpleHosting
+	instanceId, err := client.CreateInstance(
+		simplehosting.CreateInstanceRequest{
+			Name:     d.Get("name").(string),
+			Location: d.Get("location").(string),
+			Size:     d.Get("size").(string),
+			Type: &simplehosting.InstanceType{
+				Database: &simplehosting.Database{
+					Name: d.Get("database_name").(string),
+				},
+				Language: &simplehosting.Language{
+					Name: d.Get("language_name").(string),
+				},
+			},
+		},
+	)
+	if err != nil {
+		return err
+	}
+	d.SetId(instanceId)
+
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		client := meta.(*clients).SimpleHosting
+		instance, err := client.GetInstance(instanceId)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Error getting instance %s: %s", instanceId, err))
+		}
+		if instance.Status != "running" {
+			return resource.RetryableError(fmt.Errorf("Expected instance %s to be running but was in state %s", instanceId, instance.Status))
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return resourceSimpleHostingInstanceRead(d, meta)
+}
+
+func resourceSimpleHostingInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients).SimpleHosting
+	instanceId := d.Id()
+	_, err := client.DeleteInstance(instanceId)
+	if err != nil {
+		return err
+	}
+
+	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		_, err := client.GetInstance(instanceId)
+		if err != nil {
+			return nil
+		}
+		return resource.RetryableError(fmt.Errorf("The instance %s have not been deleted yet", instanceId))
+	})
+}

--- a/gandi/resource_simplehosting_instance_test.go
+++ b/gandi/resource_simplehosting_instance_test.go
@@ -1,0 +1,38 @@
+package gandi
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccSimpleHostingInstance_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigInstance(),
+			},
+		},
+	})
+}
+
+func testAccConfigInstance() string {
+	return `
+	  resource "gandi_simplehosting_instance" "create" {
+	    name = "create"
+	    size = "s+"
+	    database_name = "mysql"
+	    language_name = "php"
+	    location = "FR"
+          }
+	`
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("GANDI_KEY"); v == "" {
+		t.Fatal("GANDI_KEY must be set for acceptance tests")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/fatih/color v1.9.0 // indirect
-	github.com/go-gandi/go-gandi v0.0.0-20211207080006-e68c71983ee9
+	github.com/go-gandi/go-gandi v0.0.0-20211208125410-3b22974bcf14
 	github.com/hashicorp/go-hclog v0.10.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,7 @@ github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF0
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
+github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
@@ -84,6 +85,7 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -94,12 +96,15 @@ github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
-github.com/go-gandi/go-gandi v0.0.0-20211207080006-e68c71983ee9 h1:pNi8hTDFyA9iRLnY/ty205TFtABcxiChIiBAc2N+0z8=
-github.com/go-gandi/go-gandi v0.0.0-20211207080006-e68c71983ee9/go.mod h1:9rLNAOw2K3hRxNa3iNY+C7yHTiIr8n3x7/KaMiHnGAo=
+github.com/go-gandi/go-gandi v0.0.0-20211208125410-3b22974bcf14 h1:IwP1k5POAYqqsNwPpPErg6DnQ+omIryxvOxhdtcqtsc=
+github.com/go-gandi/go-gandi v0.0.0-20211208125410-3b22974bcf14/go.mod h1:9rLNAOw2K3hRxNa3iNY+C7yHTiIr8n3x7/KaMiHnGAo=
+github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.0.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
+github.com/go-git/go-billy/v5 v5.1.0 h1:4pl5BV4o7ZG/lterP4S6WzJ6xr49Ba5ET9ygheTYahk=
 github.com/go-git/go-billy/v5 v5.1.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-git-fixtures/v4 v4.0.2-0.20200613231340-f56387b50c12/go.mod h1:m+ICp2rF3jDhFgEZ/8yziagdT1C+ZpZcrJjappBCDSw=
+github.com/go-git/go-git/v5 v5.3.0 h1:8WKMtJR2j8RntEXR/uvTKagfEt4GYlwQ7mntE4+0GWc=
 github.com/go-git/go-git/v5 v5.3.0/go.mod h1:xdX4bWJ48aOrdhnl2XqHYstHbbp6+LFS4r4X+lNVprw=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -170,6 +175,7 @@ github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslC
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -206,10 +212,13 @@ github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 h1:Pc5TCv9mbxFN6UVX0LH6CpQrdTM5YjbVI2w15237Pjk=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
+github.com/hashicorp/terraform-exec v0.13.3 h1:R6L2mNpDGSEqtLrSONN8Xth0xYwNrnEVzDz6LF/oJPk=
 github.com/hashicorp/terraform-exec v0.13.3/go.mod h1:SSg6lbUsVB3DmFyCPjBPklqf6EYGX0TlQ6QTxOlikDU=
+github.com/hashicorp/terraform-json v0.10.0 h1:9syPD/Y5t+3uFjG8AiWVPu1bklJD8QB8iTCaJASc8oQ=
 github.com/hashicorp/terraform-json v0.10.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
 github.com/hashicorp/terraform-plugin-sdk v1.17.2 h1:V7DUR3yBWFrVB9z3ddpY7kiYVSsq4NYR67NiTs93NQo=
 github.com/hashicorp/terraform-plugin-sdk v1.17.2/go.mod h1:wkvldbraEMkz23NxkkAsFS88A1R9eUiooiaUZyS6TLw=
+github.com/hashicorp/terraform-plugin-test/v2 v2.2.1 h1:d3Rzmi5bnRzcAZon91FY4TDCMUYdU8c5vpPpf2Tz+c8=
 github.com/hashicorp/terraform-plugin-test/v2 v2.2.1/go.mod h1:eZ9JL3O69Cb71Skn6OhHyj17sLmHRb+H6VrDcJjKrYU=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
@@ -223,6 +232,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
@@ -237,6 +247,7 @@ github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfE
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -267,6 +278,7 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mitchellh/cli v1.1.2 h1:PvH+lL2B7IQ101xQL63Of8yFS2y+aDlsFcsqNc+u/Kw=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
+github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
@@ -330,6 +342,7 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -633,6 +646,7 @@ gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qS
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/h2non/gock.v1 v1.1.2 h1:jBbHXgGBK/AoPVfJh5x4r/WxIrElvbLel8TCZkkZJoY=
 gopkg.in/h2non/gock.v1 v1.1.2/go.mod h1:n7UGz/ckNChHiK05rDoiC4MYSunEC/lyaUm2WWaDva0=
+gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This resource allows to manage a SimpleHosting instance.
An acceptance test [1] has also been added.

Alone, this PR is not really useful since to actually deploy a website, it is necessary to attach a vhost to an instance. The vhost resource will be bring by a followup PR.

Note the acceptance test can currently not be executed by a CI because there is currently no way to bypass the billing:/

~~This PR is draft because it depends on https://github.com/go-gandi/go-gandi/pull/48.~~

[1] https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html

