### PR TITLE
When defining provider, use "version" instead of "versions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Note: sharing_id is optional. It is used e.g. when the API key is registered to 
 terraform {
   required_providers {
     gandi = {
-      versions = ["2.0.0-rc3"]
-      source   = "github/go-gandi/gandi"
+      version = "2.0.0-rc3"
+      source  = "github/go-gandi/gandi"
     }
   }
 }
@@ -88,8 +88,8 @@ If your zone already exists (which is very likely), you may use it as a data sou
 terraform {
   required_providers {
     gandi = {
-      versions = ["X.Y.Z"]
-      source   = "github/go-gandi/gandi"
+      version = "X.Y.Z"
+      source  = "github/go-gandi/gandi"
     }
   }
 }


### PR DESCRIPTION
Terraform 1.1.2 does not accept the plural version anymore.