### PR TITLE
GlueRecord: Fix missing Elm in schema

### DIFF
--- a/gandi/resource_glue_record.go
+++ b/gandi/resource_glue_record.go
@@ -35,6 +35,7 @@ func resourceGlueRecord() *schema.Resource {
 			},
 			"ips": {
 				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 				Required:    true,
 				Description: "List of IP addresses",
 			},


### PR DESCRIPTION
terraform version: 1.1.2
Last master up to this date: https://github.com/go-gandi/terraform-provider-gandi/commit/32504337be6783b821380860f9f410e2dc85eda2

```hcl
│ Error: Internal validation of the provider failed! This is always a bug
│ with the provider itself, and not a user issue. Please report
│ this bug:
│
│ 1 error occurred:
│ 	* resource gandi_glue_record: ips: Elem must be set for lists
│
│
│
│   with provider["github/go-gandi/gandi"],
│   on dns.tf line 1, in provider "gandi":
│    1: provider "gandi" {
│
╵
```