### PR TITLE
Deprecate the resource_domain nameservers attribute

### DIFF
--- a/gandi/resource_domain.go
+++ b/gandi/resource_domain.go
@@ -28,6 +28,7 @@ func resourceDomain() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 				Description: "A list of nameservers for the domain",
+				Deprecated:  "This nameservers attribute will be removed on next major release: the nameservers resource has to be used instead.\nSee https://github.com/go-gandi/terraform-provider-gandi/issues/88 for details.",
 			},
 			"autorenew": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
Instead, we have to use the dedidacted nameservers resource.

A terraform plan with the nameservers attribute would look like:
```

Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Warning: Argument is deprecated
│ 
│   with gandi_domain.example_com,
│   on main.tf line 22, in resource "gandi_domain" "example_com":
│   22:   nameservers = ["example.com"]
│ 
│ This nameservers attribute will be removed on next major release: the nameservers resource has to be used instead.
│ See https://github.com/go-gandi/terraform-provider-gandi/issues/88 for details.
│ 
│ (and one more similar warning elsewhere)
╵

```