### PR TITLE
livedns: do not require TTL when specifying a domain

### DIFF
--- a/docs/resources/livedns_domain.md
+++ b/docs/resources/livedns_domain.md
@@ -18,13 +18,13 @@ description: |-
 ### Required
 
 - **name** (String) The FQDN of the domain
-- **ttl** (Number) The default TTL of the domain
 
 ### Optional
 
 - **automatic_snapshots** (Boolean) Enable or disable the automatic creation of snapshots when records are changed
 - **id** (String) The ID of this resource.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- **ttl** (Number) The SOA TTL for the domain
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`


### PR DESCRIPTION
It is not possible currently to query the current TTL, making it
difficult to import and manipulate an existing domain. Make the TTL
optional solves this issue. Also update the documentation: the TTL is
for the SOA, this is not the default one.

Also, set a default value for autosnapshots (matching the current
default value). Otherwise, we have a change each time the resource is
refreshed.

Fix #55
Fix #57