### PR TITLE
Do not run acceptance tests on forked branches

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -25,6 +25,7 @@ jobs:
 
   test:
     name: Acceptance Test
+    if: github.repository == 'go-gandi/terraform-provider-gandi'
     runs-on: ubuntu-latest
     needs: lint
     steps:


### PR DESCRIPTION
Secrets are actually not available when the branch is coming from a
fork.