### PR TITLE
adjust README for 2.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Note: sharing_id is optional. It is used e.g. when the API key is registered to 
 terraform {
   required_providers {
     gandi = {
+      source = "go-gandi/gandi"
       version = "~> 2.0.0"
-      source  = "github/go-gandi/gandi"
     }
   }
 }


### PR DESCRIPTION
This just adjusts the terraform block to reference the release to the Terraform Registry

cc @nlewo 