### PR TITLE
Do not run acceptance test on PRs coming from forks

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -25,7 +25,8 @@ jobs:
 
   test:
     name: Acceptance Test
-    if: github.repository == 'go-gandi/terraform-provider-gandi'
+    # Secrets (sandbox token) are not available on forks
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs: lint
     steps:


### PR DESCRIPTION
Because secrets to access the sandbox are not available.