### PR TITLE
mutable flag for txt livedns_records

### DIFF
--- a/docs/data-sources/domain.md
+++ b/docs/data-sources/domain.md
@@ -17,14 +17,14 @@ description: |-
 
 ### Required
 
-- **name** (String) The FQDN of the domain
+- `name` (String) The FQDN of the domain
 
 ### Optional
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 ### Read-Only
 
-- **nameservers** (List of String) A list of nameservers for the domain
+- `nameservers` (List of String) A list of nameservers for the domain
 
 

--- a/docs/data-sources/glue_record.md
+++ b/docs/data-sources/glue_record.md
@@ -17,15 +17,15 @@ description: |-
 
 ### Required
 
-- **name** (String) Host name of the glue record
-- **zone** (String) Domain name
+- `name` (String) Host name of the glue record
+- `zone` (String) Domain name
 
 ### Optional
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 ### Read-Only
 
-- **ips** (List of String) A list of the ip addresses provided for the glue record
+- `ips` (List of String) A list of the ip addresses provided for the glue record
 
 

--- a/docs/data-sources/livedns_domain.md
+++ b/docs/data-sources/livedns_domain.md
@@ -17,10 +17,10 @@ description: |-
 
 ### Required
 
-- **name** (String) The FQDN of the domain
+- `name` (String) The FQDN of the domain
 
 ### Optional
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 

--- a/docs/data-sources/livedns_domain_ns.md
+++ b/docs/data-sources/livedns_domain_ns.md
@@ -17,14 +17,14 @@ description: |-
 
 ### Required
 
-- **name** (String) The FQDN of the domain
+- `name` (String) The FQDN of the domain
 
 ### Optional
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 ### Read-Only
 
-- **nameservers** (List of String) A list of nameservers for the domain
+- `nameservers` (List of String) A list of nameservers for the domain
 
 

--- a/docs/data-sources/mailbox.md
+++ b/docs/data-sources/mailbox.md
@@ -17,11 +17,11 @@ description: |-
 
 ### Required
 
-- **domain** (String) Domain name
-- **mailbox_id** (String) Mailbox ID
+- `domain` (String) Domain name
+- `mailbox_id` (String) Mailbox ID
 
 ### Optional
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/dnssec_key.md
+++ b/docs/resources/dnssec_key.md
@@ -17,13 +17,13 @@ description: |-
 
 ### Required
 
-- **algorithm** (Number) DNSSEC algorithm type
-- **domain** (String) Domain name
-- **public_key** (String) DNSSEC public key
-- **type** (String) DNSSEC key type
+- `algorithm` (Number) DNSSEC algorithm type
+- `domain` (String) Domain name
+- `public_key` (String) DNSSEC public key
+- `type` (String) DNSSEC key type
 
 ### Optional
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -17,41 +17,41 @@ description: |-
 
 ### Required
 
-- **name** (String) The FQDN of the domain
-- **owner** (Block Set, Min: 1) (see [below for nested schema](#nestedblock--owner))
+- `name` (String) The FQDN of the domain
+- `owner` (Block Set, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--owner))
 
 ### Optional
 
-- **admin** (Block Set) (see [below for nested schema](#nestedblock--admin))
-- **autorenew** (Boolean) Should the domain autorenew
-- **billing** (Block Set) (see [below for nested schema](#nestedblock--billing))
-- **id** (String) The ID of this resource.
-- **nameservers** (List of String, Deprecated) A list of nameservers for the domain
-- **tech** (Block Set) (see [below for nested schema](#nestedblock--tech))
-- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `admin` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--admin))
+- `autorenew` (Boolean) Should the domain autorenew
+- `billing` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--billing))
+- `id` (String) The ID of this resource.
+- `nameservers` (List of String, Deprecated) A list of nameservers for the domain
+- `tech` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--tech))
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 <a id="nestedblock--owner"></a>
 ### Nested Schema for `owner`
 
 Required:
 
-- **city** (String) City for the contact
-- **country** (String) The two letter country code for the contact
-- **email** (String) Contact email address
-- **family_name** (String) Family name of the contact
-- **given_name** (String) Given name of the contact
-- **phone** (String) Phone number for the contact
-- **street_addr** (String) Street Address of the contact
-- **type** (String) One of 'person', 'company', 'association', 'public body', or 'reseller'
-- **zip** (String) Postal Code/Zipcode of the contact
+- `city` (String) City for the contact
+- `country` (String) The two letter country code for the contact
+- `email` (String) Contact email address
+- `family_name` (String) Family name of the contact
+- `given_name` (String) Given name of the contact
+- `phone` (String) Phone number for the contact
+- `street_addr` (String) Street Address of the contact
+- `type` (String) One of 'person', 'company', 'association', 'public body', or 'reseller'
+- `zip` (String) Postal Code/Zipcode of the contact
 
 Optional:
 
-- **data_obfuscated** (Boolean) Whether or not to obfuscate contact data in WHOIS
-- **extra_parameters** (Map of String) Extra parameters, needed for some jurisdictions
-- **mail_obfuscated** (Boolean) Whether or not to obfuscate contact email in WHOIS
-- **organisation** (String) The legal name of the organisation. Required for types other than person
-- **state** (String) The state code for the contact
+- `data_obfuscated` (Boolean) Whether or not to obfuscate contact data in WHOIS
+- `extra_parameters` (Map of String) Extra parameters, needed for some jurisdictions
+- `mail_obfuscated` (Boolean) Whether or not to obfuscate contact email in WHOIS
+- `organisation` (String) The legal name of the organisation. Required for types other than person
+- `state` (String) The state code for the contact
 
 
 <a id="nestedblock--admin"></a>
@@ -59,23 +59,23 @@ Optional:
 
 Required:
 
-- **city** (String) City for the contact
-- **country** (String) The two letter country code for the contact
-- **email** (String) Contact email address
-- **family_name** (String) Family name of the contact
-- **given_name** (String) Given name of the contact
-- **phone** (String) Phone number for the contact
-- **street_addr** (String) Street Address of the contact
-- **type** (String) One of 'person', 'company', 'association', 'public body', or 'reseller'
-- **zip** (String) Postal Code/Zipcode of the contact
+- `city` (String) City for the contact
+- `country` (String) The two letter country code for the contact
+- `email` (String) Contact email address
+- `family_name` (String) Family name of the contact
+- `given_name` (String) Given name of the contact
+- `phone` (String) Phone number for the contact
+- `street_addr` (String) Street Address of the contact
+- `type` (String) One of 'person', 'company', 'association', 'public body', or 'reseller'
+- `zip` (String) Postal Code/Zipcode of the contact
 
 Optional:
 
-- **data_obfuscated** (Boolean) Whether or not to obfuscate contact data in WHOIS
-- **extra_parameters** (Map of String) Extra parameters, needed for some jurisdictions
-- **mail_obfuscated** (Boolean) Whether or not to obfuscate contact email in WHOIS
-- **organisation** (String) The legal name of the organisation. Required for types other than person
-- **state** (String) The state code for the contact
+- `data_obfuscated` (Boolean) Whether or not to obfuscate contact data in WHOIS
+- `extra_parameters` (Map of String) Extra parameters, needed for some jurisdictions
+- `mail_obfuscated` (Boolean) Whether or not to obfuscate contact email in WHOIS
+- `organisation` (String) The legal name of the organisation. Required for types other than person
+- `state` (String) The state code for the contact
 
 
 <a id="nestedblock--billing"></a>
@@ -83,23 +83,23 @@ Optional:
 
 Required:
 
-- **city** (String) City for the contact
-- **country** (String) The two letter country code for the contact
-- **email** (String) Contact email address
-- **family_name** (String) Family name of the contact
-- **given_name** (String) Given name of the contact
-- **phone** (String) Phone number for the contact
-- **street_addr** (String) Street Address of the contact
-- **type** (String) One of 'person', 'company', 'association', 'public body', or 'reseller'
-- **zip** (String) Postal Code/Zipcode of the contact
+- `city` (String) City for the contact
+- `country` (String) The two letter country code for the contact
+- `email` (String) Contact email address
+- `family_name` (String) Family name of the contact
+- `given_name` (String) Given name of the contact
+- `phone` (String) Phone number for the contact
+- `street_addr` (String) Street Address of the contact
+- `type` (String) One of 'person', 'company', 'association', 'public body', or 'reseller'
+- `zip` (String) Postal Code/Zipcode of the contact
 
 Optional:
 
-- **data_obfuscated** (Boolean) Whether or not to obfuscate contact data in WHOIS
-- **extra_parameters** (Map of String) Extra parameters, needed for some jurisdictions
-- **mail_obfuscated** (Boolean) Whether or not to obfuscate contact email in WHOIS
-- **organisation** (String) The legal name of the organisation. Required for types other than person
-- **state** (String) The state code for the contact
+- `data_obfuscated` (Boolean) Whether or not to obfuscate contact data in WHOIS
+- `extra_parameters` (Map of String) Extra parameters, needed for some jurisdictions
+- `mail_obfuscated` (Boolean) Whether or not to obfuscate contact email in WHOIS
+- `organisation` (String) The legal name of the organisation. Required for types other than person
+- `state` (String) The state code for the contact
 
 
 <a id="nestedblock--tech"></a>
@@ -107,23 +107,23 @@ Optional:
 
 Required:
 
-- **city** (String) City for the contact
-- **country** (String) The two letter country code for the contact
-- **email** (String) Contact email address
-- **family_name** (String) Family name of the contact
-- **given_name** (String) Given name of the contact
-- **phone** (String) Phone number for the contact
-- **street_addr** (String) Street Address of the contact
-- **type** (String) One of 'person', 'company', 'association', 'public body', or 'reseller'
-- **zip** (String) Postal Code/Zipcode of the contact
+- `city` (String) City for the contact
+- `country` (String) The two letter country code for the contact
+- `email` (String) Contact email address
+- `family_name` (String) Family name of the contact
+- `given_name` (String) Given name of the contact
+- `phone` (String) Phone number for the contact
+- `street_addr` (String) Street Address of the contact
+- `type` (String) One of 'person', 'company', 'association', 'public body', or 'reseller'
+- `zip` (String) Postal Code/Zipcode of the contact
 
 Optional:
 
-- **data_obfuscated** (Boolean) Whether or not to obfuscate contact data in WHOIS
-- **extra_parameters** (Map of String) Extra parameters, needed for some jurisdictions
-- **mail_obfuscated** (Boolean) Whether or not to obfuscate contact email in WHOIS
-- **organisation** (String) The legal name of the organisation. Required for types other than person
-- **state** (String) The state code for the contact
+- `data_obfuscated` (Boolean) Whether or not to obfuscate contact data in WHOIS
+- `extra_parameters` (Map of String) Extra parameters, needed for some jurisdictions
+- `mail_obfuscated` (Boolean) Whether or not to obfuscate contact email in WHOIS
+- `organisation` (String) The legal name of the organisation. Required for types other than person
+- `state` (String) The state code for the contact
 
 
 <a id="nestedblock--timeouts"></a>
@@ -131,6 +131,6 @@ Optional:
 
 Optional:
 
-- **default** (String)
+- `default` (String)
 
 

--- a/docs/resources/email_forwarding.md
+++ b/docs/resources/email_forwarding.md
@@ -17,11 +17,11 @@ description: |-
 
 ### Required
 
-- **destinations** (List of String) Forwards to email addresses
-- **source** (String) Account alias name
+- `destinations` (List of String) Forwards to email addresses
+- `source` (String) Account alias name
 
 ### Optional
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/glue_record.md
+++ b/docs/resources/glue_record.md
@@ -17,26 +17,26 @@ description: |-
 
 ### Required
 
-- **ips** (List of String) List of IP addresses
-- **name** (String) Host name of the glue record
-- **zone** (String) Domain name
+- `ips` (List of String) List of IP addresses
+- `name` (String) Host name of the glue record
+- `zone` (String) Domain name
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `id` (String) The ID of this resource.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
-- **fqdn** (String) The fqdn of the record
-- **fqdn_unicode** (String) The fqdn unicode of the record
-- **href** (String) The href of the record
+- `fqdn` (String) The fqdn of the record
+- `fqdn_unicode` (String) The fqdn unicode of the record
+- `href` (String) The href of the record
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`
 
 Optional:
 
-- **default** (String)
+- `default` (String)
 
 

--- a/docs/resources/livedns_domain.md
+++ b/docs/resources/livedns_domain.md
@@ -17,20 +17,20 @@ description: |-
 
 ### Required
 
-- **name** (String) The FQDN of the domain
+- `name` (String) The FQDN of the domain
 
 ### Optional
 
-- **automatic_snapshots** (Boolean) Enable or disable the automatic creation of snapshots when records are changed
-- **id** (String) The ID of this resource.
-- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- **ttl** (Number, Deprecated) The SOA TTL for the domain
+- `automatic_snapshots` (Boolean) Enable or disable the automatic creation of snapshots when records are changed
+- `id` (String) The ID of this resource.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `ttl` (Number, Deprecated) The SOA TTL for the domain
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`
 
 Optional:
 
-- **default** (String)
+- `default` (String)
 
 

--- a/docs/resources/livedns_record.md
+++ b/docs/resources/livedns_record.md
@@ -17,26 +17,27 @@ description: |-
 
 ### Required
 
-- **name** (String) The name of the record
-- **ttl** (Number) The TTL of the record
-- **type** (String) The type of the record
-- **values** (Set of String) A list of values of the record
-- **zone** (String) The FQDN of the domain
+- `name` (String) The name of the record
+- `ttl` (Number) The TTL of the record
+- `type` (String) The type of the record
+- `values` (Set of String) A list of values of the record
+- `zone` (String) The FQDN of the domain
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `id` (String) The ID of this resource.
+- `mutable` (Boolean) Define if the record can be modified outside Terraform (this currently only works for TXT records)
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
-- **href** (String) The href of the record
+- `href` (String) The href of the record
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`
 
 Optional:
 
-- **default** (String)
+- `default` (String)
 
 

--- a/docs/resources/mailbox.md
+++ b/docs/resources/mailbox.md
@@ -17,14 +17,14 @@ description: |-
 
 ### Required
 
-- **domain** (String) Domain name
-- **login** (String) Login
-- **password** (String, Sensitive) Password
+- `domain` (String) Domain name
+- `login` (String) Login
+- `password` (String, Sensitive) Password
 
 ### Optional
 
-- **aliases** (List of String) Aliases for email
-- **id** (String) The ID of this resource.
-- **mailbox_type** (String) Mailbox type
+- `aliases` (List of String) Aliases for email
+- `id` (String) The ID of this resource.
+- `mailbox_type` (String) Mailbox type
 
 

--- a/docs/resources/nameservers.md
+++ b/docs/resources/nameservers.md
@@ -17,19 +17,19 @@ description: |-
 
 ### Required
 
-- **domain** (String) The FQDN of the domain
+- `domain` (String) The FQDN of the domain
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **nameservers** (List of String) A list of nameservers for the domain
-- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `id` (String) The ID of this resource.
+- `nameservers` (List of String) A list of nameservers for the domain
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`
 
 Optional:
 
-- **default** (String)
+- `default` (String)
 
 

--- a/docs/resources/simplehosting_instance.md
+++ b/docs/resources/simplehosting_instance.md
@@ -17,22 +17,22 @@ description: |-
 
 ### Required
 
-- **database_name** (String) The name of the database type ('mysql' or 'pgsql')
-- **language_name** (String) The name of the language ('php', 'python', 'nodejs' or 'ruby')
-- **location** (String) The datacenter location of the instance ('FR' or 'LU')
-- **name** (String) The name of the SimpleHosting instance
-- **size** (String) The size of the SimpleHosting instance ('s+', 'm', 'l' or 'xxl')
+- `database_name` (String) The name of the database type ('mysql' or 'pgsql')
+- `language_name` (String) The name of the language ('php', 'python', 'nodejs' or 'ruby')
+- `location` (String) The datacenter location of the instance ('FR' or 'LU')
+- `name` (String) The name of the SimpleHosting instance
+- `size` (String) The size of the SimpleHosting instance ('s+', 'm', 'l' or 'xxl')
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `id` (String) The ID of this resource.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`
 
 Optional:
 
-- **default** (String)
+- `default` (String)
 
 

--- a/docs/resources/simplehosting_vhost.md
+++ b/docs/resources/simplehosting_vhost.md
@@ -17,25 +17,25 @@ description: |-
 
 ### Required
 
-- **fqdn** (String) The FQDN of the Vhost
-- **instance_id** (String) The ID of the SimpleHosting instance
+- `fqdn` (String) The FQDN of the Vhost
+- `instance_id` (String) The ID of the SimpleHosting instance
 
 ### Optional
 
-- **application** (String) The name of an application to install ('grav', 'matomo', 'nextcloud', 'prestashop', 'wordpress')
-- **id** (String) The ID of this resource.
-- **linked_dns_zone_alteration** (Boolean) Whether to alter the linked DNS Zone
-- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `application` (String) The name of an application to install ('grav', 'matomo', 'nextcloud', 'prestashop', 'wordpress')
+- `id` (String) The ID of this resource.
+- `linked_dns_zone_alteration` (Boolean) Whether to alter the linked DNS Zone
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
-- **certificate_id** (String) The ID of the created free certificate
+- `certificate_id` (String) The ID of the created free certificate
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`
 
 Optional:
 
-- **default** (String)
+- `default` (String)
 
 

--- a/gandi/resource_livedns_record_test.go
+++ b/gandi/resource_livedns_record_test.go
@@ -74,3 +74,137 @@ func TestAccRecord_manually_removed(t *testing.T) {
 		},
 	})
 }
+
+func TestKeepUniqueRecords(t *testing.T) {
+	recordsListFromApi := []string{"record_one", "record_two", "record_three"}
+	recordsListFromTerraform := []string{"record_one", "tf_record_two"}
+
+	t.Run("Remove duplicated record from records list", func(t *testing.T) {
+		recordsList := append(recordsListFromApi, recordsListFromTerraform...)
+		shortenedList := keepUniqueRecords(recordsList)
+
+		if !(len(shortenedList) == 4) {
+			t.Errorf("Amount of records should have been decreased by one.")
+		}
+	})
+}
+
+func TestIfRecordISWrappedWithQuotes(t *testing.T) {
+	t.Run("wrapped with quotes", func(t *testing.T) {
+		wrappedRecord := "\"192.168.0.1\""
+		if !isRecordWrappedWithQuotes(wrappedRecord) {
+			t.Errorf("%s record is wrapped with quotes.", wrappedRecord)
+		}
+	})
+
+	t.Run("suffix quote", func(t *testing.T) {
+		wrappedRecord := "192.168.0.1\""
+		if isRecordWrappedWithQuotes(wrappedRecord) {
+			t.Errorf("%s record is not wrapped with quotes.", wrappedRecord)
+		}
+	})
+
+	t.Run("prefix quote", func(t *testing.T) {
+		wrappedRecord := "\"192.168.0.1"
+		if isRecordWrappedWithQuotes(wrappedRecord) {
+			t.Errorf("%s record is not wrapped with quotes.", wrappedRecord)
+		}
+	})
+
+	t.Run("no quotes", func(t *testing.T) {
+		wrappedRecord := "192.168.0.1"
+		if isRecordWrappedWithQuotes(wrappedRecord) {
+			t.Errorf("%s record is not wrapped with quotes.", wrappedRecord)
+		}
+	})
+}
+
+func TestWrappingRecordsWithQuotes(t *testing.T) {
+	t.Run("wrapped with quotes", func(t *testing.T) {
+		records := []string{"\"192.168.0.1\"", "192.168.0.2", "192.168.0.3", "\"192.168.0.1\""}
+		wrappedRecords := wrapRecordsWithQuotes(records)
+		awaitedResult := []string{"\"192.168.0.1\"", "\"192.168.0.2\"", "\"192.168.0.3\"", "\"192.168.0.1\""}
+		if !areStringSlicesEqual(wrappedRecords, awaitedResult) {
+			t.Errorf("%s records are not wrapped with quotes.", wrappedRecords)
+		}
+	})
+}
+
+func TestIfRecordsListContainsRecord(t *testing.T) {
+	recordToCheck := "10.10.0.0"
+	t.Run("contains record at first index", func(t *testing.T) {
+		recordsList := []string{"192.168.1.1", "10.10.0.0", "0.0.0.0"}
+		index, exists := containsRecord(recordsList, recordToCheck)
+		if !exists && index != 1 {
+			t.Errorf("%s should be existing and being at index 1 of the records list", recordToCheck)
+		}
+	})
+
+	t.Run("records list does not contain the desired record", func(t *testing.T) {
+		recordsList := []string{"192.168.1.1", "10.10.10.10", "0.0.0.0"}
+		_, exists := containsRecord(recordsList, recordToCheck)
+		if exists {
+			t.Errorf("records list should not contain the desired record")
+		}
+	})
+}
+
+func TestRemoveRecordFromValuesList(t *testing.T) {
+	t.Run("remove record at first index", func(t *testing.T) {
+		recordsList := []string{"192.168.1.1", "10.10.10.10", "0.0.0.0"}
+		shortenedList := removeRecordFromValuesList(recordsList, 0)
+		awaitedList := []string{"10.10.10.10", "0.0.0.0"}
+		if !areStringSlicesEqual(shortenedList, awaitedList) {
+			t.Errorf("shortenedList should only contains 2 elements")
+		}
+	})
+
+	t.Run("remove record at third index", func(t *testing.T) {
+		recordsList := []string{"192.168.1.1", "10.10.10.10", "0.0.0.0"}
+		shortenedList := removeRecordFromValuesList(recordsList, 2)
+		awaitedList := []string{"192.168.1.1", "10.10.10.10"}
+		if !areStringSlicesEqual(shortenedList, awaitedList) {
+			t.Errorf("shortenedList should only contains 2 elements")
+		}
+	})
+}
+
+func TestGetUpdatedTXTRecordsList(t *testing.T) {
+	currentStateRecords := []string{"192.168.1.1", "192.168.1.2", "192.168.1.3"}
+	managedByHandRecords := []string{"10.10.10.10", "0.0.0.0"}
+	apiRecords := append(managedByHandRecords, currentStateRecords...)
+
+	t.Run("remove records in terraform", func(t *testing.T) {
+		nextStateRecords := []string{"192.168.1.1"}
+		updatedRecordsList := getUpdatedTXTRecordsList(currentStateRecords, apiRecords, nextStateRecords)
+		awaitedRecordsList := wrapRecordsWithQuotes(append(managedByHandRecords, nextStateRecords...))
+		if !areStringSlicesEqual(updatedRecordsList, awaitedRecordsList) {
+			t.Errorf("records list should only contains records managed by hand and new terraform records")
+		}
+	})
+
+	t.Run("add records in terraform", func(t *testing.T) {
+		nextStateRecords := append(currentStateRecords, "192.168.1.4")
+		updatedRecordsList := getUpdatedTXTRecordsList(currentStateRecords, apiRecords, nextStateRecords)
+		awaitedRecordsList := wrapRecordsWithQuotes(append(managedByHandRecords, nextStateRecords...))
+		if !areStringSlicesEqual(updatedRecordsList, awaitedRecordsList) {
+			t.Errorf("records list should only contains records managed by hand and new terraform records")
+		}
+	})
+}
+
+func TestKeepRecordsInApiAndTF(t *testing.T) {
+	terraformRecords := []string{"192.168.1.1", "192.168.1.2", "192.168.1.3"}
+	managedByHandRecords := []string{"10.10.10.10", "0.0.0.0"}
+	apiRecords := append(terraformRecords, managedByHandRecords...)
+	apiRecordsWithQuotes := wrapRecordsWithQuotes(apiRecords)
+
+	t.Run("remove terraform record by hand", func(t *testing.T) {
+		awaitedRecords := terraformRecords[1:]
+		// api returns records wrapped with quotes
+		recordsInBoth := keepRecordsInApiAndTF(terraformRecords, apiRecordsWithQuotes[1:])
+		if !areStringSlicesEqual(recordsInBoth, awaitedRecords) {
+			t.Errorf("should only contains values that are both in api and terraform")
+		}
+	})
+}

--- a/gandi/resource_livedns_record_utils.go
+++ b/gandi/resource_livedns_record_utils.go
@@ -1,0 +1,98 @@
+package gandi
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+func isRecordWrappedWithQuotes(record string) bool {
+	return strings.HasPrefix(record, "\"") && strings.HasSuffix(record, "\"")
+}
+
+func removeRecordFromValuesList(records []string, index int) []string {
+	return append(records[:index], records[index+1:]...)
+}
+
+func keepUniqueRecords(recordsList []string) []string {
+	keys := make(map[string]bool)
+	uniqueRecords := []string{}
+	for _, entry := range recordsList {
+		if _, exists := keys[entry]; !exists {
+			keys[entry] = true
+			uniqueRecords = append(uniqueRecords, entry)
+		}
+	}
+	return uniqueRecords
+}
+
+func keepRecordsInApiAndTF(tfValues []string, apiValues []string) []string {
+	var apiRecordsWithoutQuotes []string
+	for _, v := range apiValues {
+		if isRecordWrappedWithQuotes(v) {
+			apiRecordsWithoutQuotes = append(apiRecordsWithoutQuotes, strings.Trim(v, "\""))
+		} else {
+			apiRecordsWithoutQuotes = append(apiRecordsWithoutQuotes, v)
+		}
+	}
+
+	var values []string
+	for _, tfv := range tfValues {
+		for _, apiv := range apiRecordsWithoutQuotes {
+			if tfv == apiv {
+				values = append(values, apiv)
+			}
+		}
+	}
+	return values
+}
+
+func containsRecord(recordsList []string, recordToFind string) (int, bool) {
+	for i, rec := range recordsList {
+		if rec == recordToFind {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func wrapRecordsWithQuotes(records []string) []string {
+	var recordsWithQuotes []string
+	for i := range records {
+		record := fmt.Sprintf("%v", records[i])
+		if isRecordWrappedWithQuotes(record) {
+			recordsWithQuotes = append(recordsWithQuotes, record)
+		} else {
+			recordsWithQuotes = append(recordsWithQuotes, "\""+record+"\"")
+		}
+	}
+	return recordsWithQuotes
+}
+
+func areStringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	a_copy := make([]string, len(a))
+	b_copy := make([]string, len(b))
+	copy(a_copy, a)
+	copy(b_copy, b)
+	sort.Strings(a_copy)
+	sort.Strings(b_copy)
+	return reflect.DeepEqual(a_copy, b_copy)
+}
+
+func getUpdatedTXTRecordsList(stateRecords, apiRecords, newRecords []string) []string {
+	currentRecordsWithQuotes := wrapRecordsWithQuotes(stateRecords)
+	apiRecordsWithQuotes := wrapRecordsWithQuotes(apiRecords)
+	for _, v := range currentRecordsWithQuotes {
+		index, exists := containsRecord(apiRecordsWithQuotes, v)
+		if exists {
+			apiRecordsWithQuotes = removeRecordFromValuesList(apiRecordsWithQuotes, index)
+		}
+	}
+
+	records := append(wrapRecordsWithQuotes(newRecords), apiRecordsWithQuotes...)
+	return keepUniqueRecords(records)
+}


### PR DESCRIPTION
The purpose of this PR is to add a **mutable** flag on **livedns_records** to be able to manipulate records that are susceptible of being already existant / modified aside Terraform.
With this pull request, gandi provider will only touch records managed by Terraform by doing **PUT** crud operation from gandi api in order to **update/edit** the list of records.
[This is the related issue](https://github.com/go-gandi/terraform-provider-gandi/issues/106)