### PR TITLE
Add the `tags` attribute on the domain resource

### DIFF
--- a/gandi/resource_domain_test.go
+++ b/gandi/resource_domain_test.go
@@ -18,10 +18,10 @@ func TestAccDomain_basic(t *testing.T) {
 		PreCheck:   func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigDomain(resourceName, domainName),
+				Config: testAccConfig(resourceName, domainName, ""),
 			},
 			{
-				Config:            testAccConfigDomain(resourceName, domainName),
+				Config:            testAccConfig(resourceName, domainName, ""),
 				ImportState:       true,
 				ResourceName:      fmt.Sprintf("gandi_domain.%s", resourceName),
 				ImportStateId:     domainName,
@@ -31,7 +31,29 @@ func TestAccDomain_basic(t *testing.T) {
 	})
 }
 
-func testAccConfigDomain(resourceName, domainName string) string {
+func TestAccDomain_tags(t *testing.T) {
+	id := uuid.New()
+	domainName := fmt.Sprintf("terraform-provider-gandi-%s.com", id)
+	resourceName := fmt.Sprintf("terraform_provider_gandi_%s_com", id)
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(resourceName, domainName, `tags = ["tag1"]`),
+			},
+			{
+				Config: testAccConfig(resourceName, domainName, `tags = ["tag2"]`),
+			},
+			{
+				Config: testAccConfig(resourceName, domainName, ``),
+			},
+		},
+	})
+}
+
+func testAccConfig(resourceName, domainName string, tags string) string {
 	return fmt.Sprintf(`
 	  resource "gandi_domain" "%s" {
 	    name = "%s"
@@ -46,14 +68,15 @@ func testAccConfigDomain(resourceName, domainName string) string {
 	              "birth_date"               = ""
 	              "birth_department"         = ""
 	          }
-	          family_name      = "Bar"
-	          given_name       = "Foo"
+	          family_name      = "lewo"
+	          given_name       = "lewo"
 	          mail_obfuscated  = false
 	          phone            = "+33.606060606"
 	          street_addr      = "Paris"
 	          type             = "person"
 	          zip              = "75000"
 	      }
+            %s
             }
-	`, resourceName, domainName)
+	`, resourceName, domainName, tags)
 }

--- a/gandi/resource_nameservers.go
+++ b/gandi/resource_nameservers.go
@@ -43,7 +43,7 @@ func resourceNameserversCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	domain := d.Get("domain").(string)
 	d.SetId(domain)
-	nameservers := expandNameServers(d.Get("nameservers").([]interface{}))
+	nameservers := expandArray(d.Get("nameservers").([]interface{}))
 
 	if err := client.UpdateNameServers(domain, nameservers); err != nil {
 		return diag.FromErr(err)
@@ -78,7 +78,7 @@ func resourceNameserversRead(d *schema.ResourceData, meta interface{}) error {
 func resourceNameserversUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients).Domain
 	domain := d.Get("domain").(string)
-	nameservers := expandNameServers(d.Get("nameservers").([]interface{}))
+	nameservers := expandArray(d.Get("nameservers").([]interface{}))
 
 	if d.HasChange("nameservers") {
 		if err := client.UpdateNameServers(domain, nameservers); err != nil {

--- a/gandi/structures_domain.go
+++ b/gandi/structures_domain.go
@@ -84,7 +84,7 @@ func expandContact(in interface{}) *domain.Contact {
 	return nil
 }
 
-func expandNameServers(ns []interface{}) (ret []string) {
+func expandArray(ns []interface{}) (ret []string) {
 	// We need to allocate at least 0 element. Otherwise, the
 	// empty list is json encoded to null instead of [].
 	// See https://apoorvam.github.io/blog/2017/golang-json-marshal-slice-as-empty-array-not-null/

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/fatih/color v1.9.0 // indirect
-	github.com/go-gandi/go-gandi v0.4.0
+	github.com/go-gandi/go-gandi v0.5.0
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 	github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
-github.com/go-gandi/go-gandi v0.4.0 h1:iFVD+x3nJrI611fYvVMk6TKOlUOND/bKnvdQxuZKPSI=
-github.com/go-gandi/go-gandi v0.4.0/go.mod h1:9NoYyfWCjFosClPiWjkbbRK5UViaZ4ctpT8/pKSSFlw=
+github.com/go-gandi/go-gandi v0.5.0 h1:QpE/O2LHO7w5XTgAB0HaNy+hLS1oEv/j0UymYYu4D0w=
+github.com/go-gandi/go-gandi v0.5.0/go.mod h1:9NoYyfWCjFosClPiWjkbbRK5UViaZ4ctpT8/pKSSFlw=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.2.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=


### PR DESCRIPTION
This attribute allows to attach tags to a domain thanks to the tags
API:
https://api.gandi.net/docs/domains/#v5-domain-domains-domain-tags

Fixes https://github.com/go-gandi/terraform-provider-gandi/issues/125

Draft because it depends on https://github.com/go-gandi/go-gandi/pull/70