### PR TITLE
Check for status active on simplehosting instance

### DIFF
--- a/gandi/resource_simplehosting_instance.go
+++ b/gandi/resource_simplehosting_instance.go
@@ -110,8 +110,8 @@ func resourceSimpleHostingInstanceCreate(ctx context.Context, d *schema.Resource
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("Error getting instance %s: %s", instanceId, err))
 		}
-		if instance.Status != "running" {
-			return resource.RetryableError(fmt.Errorf("Expected instance %s to be running but was in state %s", instanceId, instance.Status))
+		if instance.Status != "active" {
+			return resource.RetryableError(fmt.Errorf("Expected instance %s to be active but was in state %s", instanceId, instance.Status))
 		}
 		return nil
 	})

--- a/gandi/resource_simplehosting_vhost.go
+++ b/gandi/resource_simplehosting_vhost.go
@@ -116,8 +116,8 @@ func resourceSimpleHostingVhostCreate(ctx context.Context, d *schema.ResourceDat
 			return resource.NonRetryableError(fmt.Errorf("Error getting vhost %s of instance %s: %w", instanceId, fqdn, err))
 		}
 
-		if instance.Status != "running" {
-			return resource.RetryableError(fmt.Errorf("Expected vhost %s of instance %s to be running but was in state %s", instanceId, fqdn, instance.Status))
+		if instance.Status != "active" {
+			return resource.RetryableError(fmt.Errorf("Expected vhost %s of instance %s to be active but was in state %s", instanceId, fqdn, instance.Status))
 		}
 		return nil
 	})


### PR DESCRIPTION
In an upcomming change the Gandi public API will return active status instead of running for webhosting instances.