### PR TITLE
Use dedicated organization for sandbox acceptance tests

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -37,8 +37,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Test
         env:
-          GANDI_URL: https://api.sandbox.gandi.net
-          GANDI_KEY: ${{ secrets.GANDI_SANDBOX_KEY }}
+          GANDI_URL:        https://api.sandbox.gandi.net
+          GANDI_KEY:        ${{ secrets.GANDI_SANDBOX_KEY }}
+          GANDI_SHARING_ID: a2f9c3dc-ab0e-11ee-b064-00163e6722b2
         run: |
           make testacc
 

--- a/gandi/resource_domain_test.go
+++ b/gandi/resource_domain_test.go
@@ -68,12 +68,13 @@ func testAccConfig(resourceName, domainName string, tags string) string {
 	              "birth_date"               = ""
 	              "birth_department"         = ""
 	          }
-	          family_name      = "lewo"
-	          given_name       = "lewo"
+	          organisation	   = "gandi_terraform_provider_acceptance_tests"
+	          family_name      = "Tests"
+	          given_name       = "Gandi"
 	          mail_obfuscated  = false
 	          phone            = "+33.606060606"
 	          street_addr      = "Paris"
-	          type             = "person"
+	          type             = "company"
 	          zip              = "75000"
 	      }
             %s


### PR DESCRIPTION
This MR allows CI to use a specific organization in sandbox as tests require an organization to have a pre-existing domain.
Users in this organization can run the tests by setting their own apikey as long as they have the rights to manage this organization.