### PR TITLE
Fix provider version in doc example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Use the navigation to the left to read about the available resources.
 terraform {
   required_providers {
     gandi = {
-      version = "~> 2.0.0"
+      version = "~> 2.3"
       source   = "go-gandi/gandi"
     }
   }


### PR DESCRIPTION
Currently copy/pasting the example doesn't work as it uses PAT but download 2.0.x version which doesn't support it.