### PR TITLE
Remove APIKey

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -35,13 +35,6 @@ jobs:
           go-version: 1.17
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-      - name: Test with apikey
-        env:
-          GANDI_URL: https://api.sandbox.gandi.net
-          GANDI_KEY: ${{ secrets.GANDI_SANDBOX_KEY }}
-          GANDI_SHARING_ID: a2f9c3dc-ab0e-11ee-b064-00163e6722b2
-        run: |
-          make testacc
       - name: Test with personal access token
         env:
           GANDI_URL: https://api.sandbox.gandi.net

--- a/gandi/provider.go
+++ b/gandi/provider.go
@@ -23,14 +23,6 @@ func Provider() *schema.Provider {
 				Description: "A Gandi API Personal Access Token",
 				Sensitive:   true,
 			},
-			"key": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("GANDI_KEY", nil),
-				Description: "(DEPRECATED) A Gandi API key",
-				Deprecated:  "use personal_access_token instead",
-				Sensitive:   true,
-			},
 			"sharing_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -84,7 +76,6 @@ type clients struct {
 func getGandiClients(d *schema.ResourceData) (interface{}, error) {
 	config := config.Config{
 		APIURL:              d.Get("url").(string),
-		APIKey:              d.Get("key").(string),
 		PersonalAccessToken: d.Get("personal_access_token").(string),
 		SharingID:           d.Get("sharing_id").(string),
 		DryRun:              d.Get("dry_run").(bool),

--- a/gandi/provider_test.go
+++ b/gandi/provider_test.go
@@ -28,8 +28,8 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if os.Getenv("GANDI_PERSONAL_ACCESS_TOKEN") == "" && os.Getenv("GANDI_KEY") == "" {
-		t.Fatal("GANDI_PERSONAL_ACCESS_TOKEN or GANDI_KEY must be set for acceptance tests")
+	if os.Getenv("GANDI_PERSONAL_ACCESS_TOKEN") == ""  {
+		t.Fatal("GANDI_PERSONAL_ACCESS_TOKEN must be set for acceptance tests")
 	}
 	if os.Getenv("GANDI_URL") == "" {
 		t.Fatal("GANDI_URL must be set for acceptance tests")

--- a/gandi/resource_livedns_record_test.go
+++ b/gandi/resource_livedns_record_test.go
@@ -44,7 +44,6 @@ func deleteRecord() {
 	config := config.Config{
 		APIURL:              os.Getenv("GANDI_URL"),
 		PersonalAccessToken: os.Getenv("GANDI_PERSONAL_ACCESS_TOKEN"),
-		APIKey:              os.Getenv("GANDI_KEY"),
 		SharingID:           os.Getenv("GANDI_SHARING_ID"),
 		Debug:               logging.IsDebugOrHigher(),
 	}
@@ -232,7 +231,6 @@ func updateRecord(values []string) {
 	config := config.Config{
 		APIURL:              os.Getenv("GANDI_URL"),
 		PersonalAccessToken: os.Getenv("GANDI_PERSONAL_ACCESS_TOKEN"),
-		APIKey:              os.Getenv("GANDI_KEY"),
 		SharingID:           os.Getenv("GANDI_SHARING_ID"),
 		Debug:               logging.IsDebugOrHigher(),
 	}
@@ -252,7 +250,6 @@ func checkRecordValuesOnAPI(state *terraform.State, expected []string) error {
 	config := config.Config{
 		APIURL:              os.Getenv("GANDI_URL"),
 		PersonalAccessToken: os.Getenv("GANDI_PERSONAL_ACCESS_TOKEN"),
-		APIKey:              os.Getenv("GANDI_KEY"),
 		SharingID:           os.Getenv("GANDI_SHARING_ID"),
 		Debug:               logging.IsDebugOrHigher(),
 	}


### PR DESCRIPTION
As mentioned in https://github.com/go-gandi/terraform-provider-gandi/issues/154 we cannot use anymore this provider. 

I removed the APIkey as it is not possible to generate one. Not it is just with PAT (as the doc mention it already) 