### PR TITLE
Fix gandi_email_forwarding resource import

### DIFF
--- a/gandi/resource_email_forwarding.go
+++ b/gandi/resource_email_forwarding.go
@@ -139,9 +139,6 @@ func resourceEmailForwardingImport(d *schema.ResourceData, meta interface{}) (da
 		}
 	}
 
-	if err = d.Set("href", response.Href); err != nil {
-		return nil, fmt.Errorf("failed to set href for %s: %s", d.Id(), err)
-	}
 	sort.Strings(response.Destinations)
 	if err = d.Set("destinations", response.Destinations); err != nil {
 		return nil, fmt.Errorf("failed to set destinations for %s: %s", d.Id(), err)


### PR DESCRIPTION
Remove `d.Set("href", response.Href);`. It triggers an error since "href" doesn't exist in resource.

Fix #161 